### PR TITLE
refactor: GDD Number Formatting

### DIFF
--- a/src/components/TransactionTypes/DecayDetails.ts
+++ b/src/components/TransactionTypes/DecayDetails.ts
@@ -3,7 +3,9 @@ import dropletHalfIcon from '~icons/bi/droplet-half'
 import type { WalletTransaction } from '../../client/output.schema'
 import { DecayType } from '../../enum/DecayType'
 import { getUserTransactionTypeLabel } from '../../enum/UserTransactionType'
-import { formatDistance, formatGDD4 } from '../../utils/utils'
+import { formatDistance } from '../../utils/utils'
+import { FormattedCurrency } from '../view/FormattedCurrency'
+import { CONFIG } from '../../config'
 
 export class DecayDetails implements m.ClassComponent<WalletTransaction> {
   viewTitle(attrs: WalletTransaction) {
@@ -57,33 +59,46 @@ export class DecayDetails implements m.ClassComponent<WalletTransaction> {
     return attrs.decay && attrs.decay.type !== DecayType.BEFORE_START_BLOCK
       ? m('.row.mt-0', [
           m('.col-sm-6.col-md-6.col-lg-3.col-6', t.__('Decay')),
-          m('.offset-0.col.offset-0.text-end.me-0', formatGDD4(attrs.decay.decay)),
+          m('.offset-0.col.offset-0.text-end.me-0', 
+            m(FormattedCurrency, { value: attrs.decay.decay, decimalPlaces: CONFIG.FULL_DECIMAL_PLACES ? 4 : 2 })
+          )
         ])
       : undefined
   }
 
   view({ attrs }: m.CVnode<WalletTransaction>) {
+    const decimalPlaces = CONFIG.FULL_DECIMAL_PLACES ? 4 : 2
     return [
       this.viewTitle(attrs),
       this.viewDateTime(attrs),
       m('.row.mt-2', [
         m('.col-sm-6.col-md-6.col-lg-4.col-6', t.__('Previous balance')),
-        m('.offset-0.col.offset-0.text-end.me-0', formatGDD4(attrs.previousBalance)),
+        m('.offset-0.col.offset-0.text-end.me-0', 
+          m(FormattedCurrency, { value: attrs.previousBalance, decimalPlaces })
+        )
       ]),
       this.viewDecay(attrs),
       m('.row', [
         m('.col-sm-6.col-md-6.col-lg-3.col-6', getUserTransactionTypeLabel(attrs.typeId)),
-        m('.offset-0.col.offset-0.text-end.me-0', formatGDD4(attrs.amount)),
+        m('.offset-0.col.offset-0.text-end.me-0', 
+          m(FormattedCurrency, { value: attrs.amount, decimalPlaces })
+        ),
       ]),
       attrs.change
         ? m('.row.mt-0', [
             m('.col-sm-6.col-md-6.col-lg-4.col-6', t.__('Change')),
-            m('.offset-0.col.offset-0.text-end.me-0', formatGDD4(attrs.change.amount)),
+            m('.offset-0.col.offset-0.text-end.me-0', 
+              m(FormattedCurrency, { value: attrs.change.amount, decimalPlaces })
+            ),
           ])
         : undefined,
       m('.row.border-top.pt-2.mt-2', [
         m('.col-sm-6.col-md-6.col-lg-3.col-6', t.__('New balance')),
-        m('.offset-0.col.offset-0.text-end.me-0', m('b', formatGDD4(attrs.balance))),
+        m('.offset-0.col.offset-0.text-end.me-0', 
+          m('b', 
+            m(FormattedCurrency, { value: attrs.balance, decimalPlaces })
+          )
+        ),
       ]),
     ]
   }

--- a/src/components/TransactionTypes/DecayDetailsShort.ts
+++ b/src/components/TransactionTypes/DecayDetailsShort.ts
@@ -1,13 +1,18 @@
 import m from 'mithril'
 import dropletHalfIcon from '~icons/bi/droplet-half'
 import type { WalletTransaction } from '../../client/output.schema'
-import { formatGDD } from '../../utils/utils'
+import { FormattedCurrency } from '../view/FormattedCurrency'
 
 export class DecayDetailsShort implements m.ClassComponent<WalletTransaction> {
   constructDecayString({ previousBalance, decay, balance }: WalletTransaction): m.ChildArray {
-    const formattedPrevious = formatGDD(previousBalance)
-    const formattedDecay = decay ? (decay.decay === '0' ? t.__('− ') : formatGDD(decay.decay)) : ''
-    const formattedBalance = formatGDD(balance)
+    const formattedPrevious = m(FormattedCurrency, { value: previousBalance })
+    let formattedDecay: m.Child
+    if (decay && decay.decay !== '0') {
+      formattedDecay = m(FormattedCurrency, { value: decay.decay })
+    } else {
+      formattedDecay = t.__('− ')
+    }
+    const formattedBalance = m(FormattedCurrency, { value: balance })
 
     return [formattedPrevious, ' ', formattedDecay, ' ', t.__('='), ' ', m('b', formattedBalance)]
   }
@@ -23,8 +28,8 @@ export class DecayDetailsShort implements m.ClassComponent<WalletTransaction> {
         m(
           '.col',
           m('.row', [
-            m('.col-md-4.col-lg-4.col-12', m('', t.__('Decay'))),
-            m('.offset-1.offset-lg-0.offset-md-0.col', m('', this.constructDecayString(attrs))),
+            m('.col-md-4.col-lg-4.col-12', t.__('Decay')),
+            m('.offset-1.offset-lg-0.offset-md-0.col', this.constructDecayString(attrs)),
           ]),
         ),
       ),

--- a/src/components/WalletSum.ts
+++ b/src/components/WalletSum.ts
@@ -1,6 +1,7 @@
 import m from 'mithril'
-import { combineElementWithClasses, formatCurrency, stringToBoolean } from '../utils/utils'
+import { combineElementWithClasses, stringToBoolean } from '../utils/utils'
 import { Eye } from './view/Eye'
+import { FormattedCurrency } from './view/FormattedCurrency'
 
 interface Attrs {
   amount: string
@@ -63,7 +64,7 @@ export class WalletSum implements m.ClassComponent<Attrs> {
                 ),
                 m(
                   'span.fw-bold.gradido-global-color-accent',
-                  this.state.show ? formatCurrency(attrs.amount, attrs.unit) : '****',
+                  this.state.show ? m(FormattedCurrency, { value: attrs.amount, currency: attrs.unit }) : '****',
                 ),
               ]),
               m(

--- a/src/components/view/DetailsBlock.ts
+++ b/src/components/view/DetailsBlock.ts
@@ -1,8 +1,8 @@
 import m from 'mithril'
-import { formatGDD } from '../../utils/utils'
 import { Collapse } from './bootstrap/Collapse'
 import { CollapseArrow } from './CollapseArrow'
 import { PublicKeyLink } from './PublicKeyLink'
+import { FormattedCurrency } from './FormattedCurrency'
 
 export interface DetailsBlockAttrs {
   firstRow: m.Child
@@ -33,9 +33,9 @@ export class DetailsBlock implements m.ClassComponent<DetailsBlockAttrs> {
 
   amountView(amount: string): m.Child {
     if (this.isAmountPositive(amount)) {
-      return m('.fw-bold.gradido-global-color-accent', formatGDD(amount))
+      return m('.fw-bold.gradido-global-color-accent', m(FormattedCurrency, { value: amount }))
     } else {
-      return m('.fw-bold', formatGDD(amount))
+      return m('.fw-bold', m(FormattedCurrency, { value: amount }))
     }
   }
 

--- a/src/components/view/FormattedCurrency.ts
+++ b/src/components/view/FormattedCurrency.ts
@@ -9,7 +9,7 @@ export interface FormattedCurrencyAttrs {
 
 export class FormattedCurrency implements m.ClassComponent<FormattedCurrencyAttrs> {
   formatDecimalPart(decimalPart: string, decimalPlaces: number): m.Child[] {
-    if (decimalPlaces > 2) {      
+    if (decimalPlaces > 2) {
       return [
         decimalPart.slice(0, 2),
         m('span.gdd-precision-fractional-places', decimalPart.slice(2 - decimalPlaces))
@@ -28,7 +28,9 @@ export class FormattedCurrency implements m.ClassComponent<FormattedCurrencyAttr
       ' ',
       currencyParts.intPart,
       currencyParts.decimalSeparator,
-      ...decimalPart
+      ...decimalPart,
+      ' ',
+      currencyParts.currencySymbol,
     ])
   }
 }

--- a/src/components/view/FormattedCurrency.ts
+++ b/src/components/view/FormattedCurrency.ts
@@ -1,0 +1,34 @@
+import m from 'mithril'
+import { createCurrencyDisplayParts } from '../../utils/utils'
+
+export interface FormattedCurrencyAttrs {
+  value: string
+  decimalPlaces?: number
+  currency?: string // default to GDD
+}
+
+export class FormattedCurrency implements m.ClassComponent<FormattedCurrencyAttrs> {
+  formatDecimalPart(decimalPart: string, decimalPlaces: number): m.Child[] {
+    if (decimalPlaces > 2) {      
+      return [
+        decimalPart.slice(0, 2),
+        m('span.gdd-precision-fractional-places', decimalPart.slice(2 - decimalPlaces))
+      ]
+    } else {
+      return [decimalPart]
+    }
+  }
+  view({ attrs: { value, decimalPlaces, currency } }: m.CVnode<FormattedCurrencyAttrs>) {
+    // ?? instead of || to allow 0 value for decimalPlaces
+    const localDecimalPlaces = decimalPlaces ?? 2
+    const currencyParts = createCurrencyDisplayParts(value, localDecimalPlaces, currency)
+    const decimalPart = this.formatDecimalPart(currencyParts.decPart, localDecimalPlaces)
+    return m('span', [
+      currencyParts.sign,
+      ' ',
+      currencyParts.intPart,
+      currencyParts.decimalSeparator,
+      ...decimalPart
+    ])
+  }
+}

--- a/src/components/view/transaction/AccountBalances.view.ts
+++ b/src/components/view/transaction/AccountBalances.view.ts
@@ -4,9 +4,9 @@ import {
   getBalanceDerivationTypeString,
 } from '../../../enum/BalanceDerivationType'
 import type { AccountBalance } from '../../../schemas/transaction.schema'
-import { formatCurrency } from '../../../utils/utils'
 import { CommunityLink } from '../CommunityLink'
 import { PublicKeyLink } from '../PublicKeyLink'
+import { FormattedCurrency } from '../FormattedCurrency'
 
 interface ViewAttrs {
   accountBalances: AccountBalance[]
@@ -38,7 +38,7 @@ export class AccountBalancesView implements m.ClassComponent<ViewAttrs> {
           ]),
           m('.row', [
             m('.col', t.__('Balance')),
-            m('.col.text-end', formatCurrency(accountBalance.balance)),
+            m('.col.text-end', m(FormattedCurrency, { value: accountBalance.balance })),
           ]),
           accountBalance.coinCommunityId && accountBalance.coinCommunityId !== attrs.communityId
             ? m('.row', [

--- a/src/components/view/transaction/TransferAmount.view.ts
+++ b/src/components/view/transaction/TransferAmount.view.ts
@@ -1,8 +1,8 @@
 import m from 'mithril'
 import type { TransferAmount } from '../../../schemas/basic.schema'
-import { formatCurrency4 } from '../../../utils/utils'
 import { CommunityLink } from '../CommunityLink'
 import { PublicKeyLink } from '../PublicKeyLink'
+import { FormattedCurrency } from '../FormattedCurrency'
 
 interface ViewAttrs {
   transferAmount: TransferAmount
@@ -26,7 +26,7 @@ export class TransferAmountView implements m.ClassComponent<ViewAttrs> {
       ]),
       m('.row', [
         m('.col', t.__('Amount')),
-        m('.col.text-end', formatCurrency4(attrs.transferAmount.amount)),
+        m('.col.text-end', m(FormattedCurrency, { value: attrs.transferAmount.amount })),
       ]),
       attrs.transferAmount.communityId
         ? m('.row', [

--- a/src/pages/Transaction.ts
+++ b/src/pages/Transaction.ts
@@ -44,6 +44,7 @@ export class Transaction implements m.ClassComponent<Attrs> {
         })
       }
       // console.log(this.transactionResponse)
+      this.transactionResponse?.transaction.id
       m.redraw()
     } catch (e) {
       toaster.error(e)

--- a/src/schemas/basic.schema.ts
+++ b/src/schemas/basic.schema.ts
@@ -92,3 +92,14 @@ export const ledgerAnchorSchema = v.pipe(
 )
 
 export type LedgerAnchor = v.InferOutput<typeof ledgerAnchorSchema>
+
+export const currencyDisplayPartsSchema = v.object({
+  sign: v.string(),
+  intPart: v.string(),
+  decimalSeparator: v.string(),
+  decPart: v.string(),
+  currencySymbol: v.string()
+})
+
+export type CurrencyDisplayParts = v.InferOutput<typeof currencyDisplayPartsSchema>
+

--- a/src/schemas/transaction.schema.ts
+++ b/src/schemas/transaction.schema.ts
@@ -71,7 +71,6 @@ export const transactionBodySchema = v.pipe(
   v.object({
     memos: v.array(encryptedMemoSchema),
     createdAt: dateSchema,
-    versionNumber: v.string(),
     type: v.enum(CrossGroupType),
     otherCommunity: v.nullish(v.string()),
     communityRoot: v.nullish(communityRootSchema),
@@ -119,7 +118,6 @@ export const confirmedTransactionSchema = v.object({
   id: v.number(),
   gradidoTransaction: gradidoTransactionSchema,
   confirmedAt: dateSchema,
-  versionNumber: v.string(),
   runningHash: hex32Schema,
   ledgerAnchor: ledgerAnchorSchema,
   accountBalances: v.array(accountBalanceSchema),

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -15,6 +15,9 @@ body {
   margin-top: -0.5rem !important;
 }
 
+.gdd-precision-fractional-places {
+  color: #8a93a6;
+}
 
 @media screen and (width <= 450px) {
   .breadcrumb {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
-import { CONFIG } from '../config'
+import { CurrencyDisplayParts, currencyDisplayPartsSchema } from '../schemas/basic.schema'
+import * as v from 'valibot'
 
 export function getEnumValue<T extends string | number>(value: string | null, defaultValue: T): T {
   if (!value) {
@@ -12,63 +13,58 @@ export function getEnumValue<T extends string | number>(value: string | null, de
   return defaultValue
 }
 
-export function formatCurrency(value: string, currency: string = 'GDD'): string {
-  const numericValue = parseFloat(value)
-  if (Number.isNaN(numericValue)) {
-    return ''
-  }
-
-  const truncatedValue = numericValue // Math.floor(numericValue * 100) / 100
-
-  const decimalPlaces = CONFIG.FULL_DECIMAL_PLACES ? 4 : 2
-  return new Intl.NumberFormat(t.getLocale(), {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: decimalPlaces,
-    maximumFractionDigits: decimalPlaces,
-  })
-    .format(truncatedValue)
-    .replace('-', t.__('− '))
+const POW10: Record<number, number> = {
+  0: 1,
+  1: 10,
+  2: 100,
+  3: 1000,
+  4: 10000,
 }
 
-export function formatCurrency4(value: string, currency: string = 'GDD'): string {
-  const numericValue = parseFloat(value)
-  if (Number.isNaN(numericValue)) {
-    return ''
+export function createCurrencyDisplayParts(value: string, fractionDigits: number = 2, currency?: string): CurrencyDisplayParts {
+  const result = {
+    sign: '',
+    intPart: '',
+    decimalSeparator: '',
+    decPart: '',
+    currencySymbol: currency || 'GDD',
   }
-
-  const truncatedValue = Math.floor(numericValue * 10000) / 10000
-
-  return new Intl.NumberFormat(t.getLocale(), {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 4,
-  })
-    .format(truncatedValue)
-    .replace('-', t.__('− '))
-}
-
-export function formatGDD(value: string): string {
-  const firstStep = formatCurrency(value)
-  if (firstStep.length) {
-    const numericValue = parseFloat(value)
-    if (numericValue > 0) {
-      return `${t.__('+')} ${firstStep}`
+  const numericValue = parseFloat(value)
+  if (fractionDigits > 4) {
+    throw new Error('fractionDigits must be less than or equal to 4')
+  }
+  if (!Number.isNaN(numericValue)) {
+    const truncatedValue = Math.round(numericValue * POW10[fractionDigits]) / POW10[fractionDigits]
+    const parts = new Intl.NumberFormat(t.getLocale(), {
+      style: 'decimal',
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+      useGrouping: true, 
+    }).formatToParts(truncatedValue)
+    if (truncatedValue > 0) {
+      result.sign = t.__('+')
+    } else if (truncatedValue < 0) {
+      result.sign = t.__('−')
+    }
+    for (const part of parts) {
+      switch (part.type) {
+        case 'integer':
+        case 'group':
+          result.intPart += part.value
+          break
+        case 'decimal':
+          result.decimalSeparator = part.value
+          break
+        case 'fraction':
+          result.decPart = part.value
+          break
+      }
     }
   }
-  return firstStep
+  
+  return v.parse(currencyDisplayPartsSchema, result)
 }
-export function formatGDD4(value: string): string {
-  const firstStep = formatCurrency4(value)
-  if (firstStep.length) {
-    const numericValue = parseFloat(value)
-    if (numericValue > 0) {
-      return `${t.__('+')} ${firstStep}`
-    }
-  }
-  return firstStep
-}
+
 
 export function combineElementWithClasses(element: string, classes?: string[]) {
   let elementWithClasses = element


### PR DESCRIPTION
Add structured currency formatting with UI-friendly display parts

- Introduce `CurrencyDisplayParts` type to represent a parsed and UI-ready breakdown of a formatted currency value (sign, integer part, decimal separator, fractional part, and currency symbol)

- Add `currencyDisplayPartsSchema` (Valibot) to validate the structure of formatted currency data and ensure consistency at runtime

- Implement `createCurrencyDisplayParts` utility function which:
  - Parses numeric string values
  - Uses Intl.NumberFormat.formatToParts for locale-aware formatting
  - Truncates values to a fixed number of decimal places
  - Splits formatted numbers into structured parts for UI rendering

- Add `FormattedCurrency` Mithril component responsible for rendering currency values using the structured format instead of raw formatted strings
  - Supports configurable decimal places
  - Supports optional currency symbol
  - Visually emphasizes the first 2 fractional digits
  - Renders additional fractional digits in a muted style for reduced visual importance

- Replace all previous usages of `formatCurrency`, `formatCurrency4`, `formatGDD`, and `formatGDD4` across the codebase with the new `FormattedCurrency` component

This refactor improves separation of concerns:
- Formatting logic is now centralized 
- UI rendering is fully component-based and no longer depends on preformatted strings
- Currency display is more flexible and allows styling individual numeric parts (e.g. muting less important decimal places)